### PR TITLE
Uncomment imports to resolve undefined names

### DIFF
--- a/lib/pycocotools/coco.py
+++ b/lib/pycocotools/coco.py
@@ -47,9 +47,9 @@ __version__ = '1.0.1'
 import json
 import datetime
 import time
-# import matplotlib.pyplot as plt
-# from matplotlib.collections import PatchCollection
-# from matplotlib.patches import Polygon
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Polygon
 import numpy as np
 # from skimage.draw import polygon
 import urllib


### PR DESCRIPTION
```
./lib/pycocotools/coco.py:248:18: F821 undefined name 'plt'
            ax = plt.gca()
                 ^
./lib/pycocotools/coco.py:257:41: F821 undefined name 'Polygon'
                        polygons.append(Polygon(poly, True,alpha=0.4))
                                        ^
./lib/pycocotools/coco.py:275:17: F821 undefined name 'PatchCollection'
            p = PatchCollection(polygons, facecolors=color, edgecolors=(0,0,0,1), linewidths=3, alpha=0.4)
                ^
```