### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -37,6 +37,12 @@ from model.faster_rcnn.vgg16 import vgg16
 from model.faster_rcnn.resnet import resnet
 import pdb
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 def parse_args():
   """
   Parse input arguments
@@ -44,7 +50,7 @@ def parse_args():
   parser = argparse.ArgumentParser(description='Train a Fast R-CNN network')
   parser.add_argument('--dataset', dest='dataset',
                       help='training dataset',
-                      default='pascal_voc', type=str)  
+                      default='pascal_voc', type=str)
   parser.add_argument('--cfg', dest='cfg_file',
                       help='optional config file',
                       default='cfgs/vgg16.yml', type=str)
@@ -59,7 +65,7 @@ def parse_args():
                       nargs=argparse.REMAINDER)
   parser.add_argument('--image_dir', dest='image_dir',
                       help='directory to load images for demo', default="images",
-                      nargs=argparse.REMAINDER)                      
+                      nargs=argparse.REMAINDER)
   parser.add_argument('--cuda', dest='cuda',
                       help='whether use CUDA',
                       action='store_true')
@@ -68,7 +74,7 @@ def parse_args():
                       action='store_true')
   parser.add_argument('--cag', dest='class_agnostic',
                       help='whether perform class_agnostic bbox regression',
-                      action='store_true')                      
+                      action='store_true')
   parser.add_argument('--parallel_type', dest='parallel_type',
                       help='which part of model to parallel, 0: all, 1: model before roi pooling',
                       default=0, type=int)
@@ -86,7 +92,7 @@ def parse_args():
                       default=1, type=int)
   parser.add_argument('--vis', dest='vis',
                       help='visualization mode',
-                      action='store_true')  
+                      action='store_true')
   args = parser.parse_args()
   return args
 
@@ -174,7 +180,7 @@ if __name__ == '__main__':
     pdb.set_trace()
 
   fasterRCNN.create_architecture()
-  
+
   print("load checkpoint %s" % (load_name))
   checkpoint = torch.load(load_name)
   fasterRCNN.load_state_dict(checkpoint['model'])
@@ -259,7 +265,7 @@ if __name__ == '__main__':
       rpn_loss_cls, rpn_loss_box, \
       RCNN_loss_cls, RCNN_loss_bbox, \
       rois_label = fasterRCNN(im_data, im_info, gt_boxes, num_boxes)
-      
+
       scores = cls_prob.data
       boxes = rois.data[:, :, 1:5]
 
@@ -285,7 +291,7 @@ if __name__ == '__main__':
 
       pred_boxes /= im_scales[0]
 
-      scores = scores.squeeze()    
+      scores = scores.squeeze()
       pred_boxes = pred_boxes.squeeze()
       det_toc = time.time()
       detect_time = det_toc - det_tic

--- a/lib/datasets/imagenet.py
+++ b/lib/datasets/imagenet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -16,6 +17,12 @@ import scipy.io as sio
 import cPickle
 import subprocess
 import pdb
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class imagenet(imdb):
     def __init__(self, image_set, devkit_path, data_path):
@@ -151,14 +158,14 @@ class imagenet(imdb):
         if os.path.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} gt roidb loaded from {}'.format(self.name, cache_file)
+            print('{} gt roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         gt_roidb = [self._load_imagenet_annotation(index)
                     for index in self.image_index]
         with open(cache_file, 'wb') as fid:
             cPickle.dump(gt_roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote gt roidb to {}'.format(cache_file)
+        print('wrote gt roidb to {}'.format(cache_file))
 
         return gt_roidb
 

--- a/lib/datasets/pascal_voc.py
+++ b/lib/datasets/pascal_voc.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -21,13 +23,17 @@ import xml.etree.ElementTree as ET
 
 from .imdb import imdb
 from .imdb import ROOT_DIR
-import ds_utils
+from . import ds_utils
 from .voc_eval import voc_eval
 
 # TODO: make fast_rcnn irrelevant
 # >>>> obsolete, because it depends on sth outside of this project
 from model.utils.config import cfg
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 # <<<< obsolete
 
@@ -120,14 +126,14 @@ class pascal_voc(imdb):
         if os.path.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} gt roidb loaded from {}'.format(self.name, cache_file)
+            print('{} gt roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         gt_roidb = [self._load_pascal_annotation(index)
                     for index in self.image_index]
         with open(cache_file, 'wb') as fid:
             cPickle.dump(gt_roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote gt roidb to {}'.format(cache_file)
+        print('wrote gt roidb to {}'.format(cache_file))
 
         return gt_roidb
 
@@ -144,7 +150,7 @@ class pascal_voc(imdb):
         if os.path.exists(cache_file):
             with open(cache_file, 'rb') as fid:
                 roidb = cPickle.load(fid)
-            print '{} ss roidb loaded from {}'.format(self.name, cache_file)
+            print('{} ss roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         if int(self._year) == 2007 or self._image_set != 'test':
@@ -155,7 +161,7 @@ class pascal_voc(imdb):
             roidb = self._load_selective_search_roidb(None)
         with open(cache_file, 'wb') as fid:
             cPickle.dump(roidb, fid, cPickle.HIGHEST_PROTOCOL)
-        print 'wrote ss roidb to {}'.format(cache_file)
+        print('wrote ss roidb to {}'.format(cache_file))
 
         return roidb
 
@@ -171,7 +177,7 @@ class pascal_voc(imdb):
 
     def _load_rpn_roidb(self, gt_roidb):
         filename = self.config['rpn_file']
-        print 'loading {}'.format(filename)
+        print('loading {}'.format(filename))
         assert os.path.exists(filename), \
             'rpn data not found at: {}'.format(filename)
         with open(filename, 'rb') as f:
@@ -268,7 +274,7 @@ class pascal_voc(imdb):
         for cls_ind, cls in enumerate(self.classes):
             if cls == '__background__':
                 continue
-            print 'Writing {} VOC results file'.format(cls)
+            print('Writing {} VOC results file'.format(cls))
             filename = self._get_voc_results_file_template().format(cls)
             with open(filename, 'wt') as f:
                 for im_ind, index in enumerate(self.image_index):
@@ -298,7 +304,7 @@ class pascal_voc(imdb):
         aps = []
         # The PASCAL VOC metric changed in 2010
         use_07_metric = True if int(self._year) < 2010 else False
-        print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+        print('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
         if not os.path.isdir(output_dir):
             os.mkdir(output_dir)
         for i, cls in enumerate(self._classes):
@@ -328,9 +334,9 @@ class pascal_voc(imdb):
         print('--------------------------------------------------------------')
 
     def _do_matlab_eval(self, output_dir='output'):
-        print '-----------------------------------------------------'
-        print 'Computing results with the official MATLAB eval code.'
-        print '-----------------------------------------------------'
+        print('-----------------------------------------------------')
+        print('Computing results with the official MATLAB eval code.')
+        print('-----------------------------------------------------')
         path = os.path.join(cfg.ROOT_DIR, 'lib', 'datasets',
                             'VOCdevkit-matlab-wrapper')
         cmd = 'cd {} && '.format(path)

--- a/lib/datasets/tools/mcg_munge.py
+++ b/lib/datasets/tools/mcg_munge.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 
@@ -28,7 +29,7 @@ def munge(src_dir):
             os.makedirs(dst_dir)
         src = os.path.join(src_dir, fn)
         dst = os.path.join(dst_dir, fn)
-        print 'MV: {} -> {}'.format(src, dst)
+        print('MV: {} -> {}'.format(src, dst))
         os.rename(src, dst)
 
 if __name__ == '__main__':

--- a/lib/datasets/vg.py
+++ b/lib/datasets/vg.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -15,10 +17,16 @@ import cPickle
 import gzip
 import PIL
 import json
-from vg_eval import vg_eval
+from .vg_eval import vg_eval
 from model.utils.config import cfg
 import pickle
 import pdb
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class vg(imdb):
     def __init__(self, version, image_set, ):
@@ -121,11 +129,11 @@ class vg(imdb):
         if self._image_set == "minitrain":
           return os.path.join(self._data_path, 'train.txt')
         if self._image_set == "smalltrain":
-          return os.path.join(self._data_path, 'train.txt')          
+          return os.path.join(self._data_path, 'train.txt')
         if self._image_set == "minival":
           return os.path.join(self._data_path, 'val.txt')
         if self._image_set == "smallval":
-          return os.path.join(self._data_path, 'val.txt')          
+          return os.path.join(self._data_path, 'val.txt')
         else:
           return os.path.join(self._data_path, self._image_set+'.txt')
 
@@ -141,7 +149,7 @@ class vg(imdb):
           if self._image_set == "minitrain":
             metadata = metadata[:1000]
           elif self._image_set == "smalltrain":
-            metadata = metadata[:20000]            
+            metadata = metadata[:20000]
           elif self._image_set == "minival":
             metadata = metadata[:100]
           elif self._image_set == "smallval":
@@ -172,13 +180,13 @@ class vg(imdb):
         Return the database of ground-truth regions of interest.
 
         This function loads/saves from/to a cache file to speed up future calls.
-        """        
+        """
         cache_file = os.path.join(self.cache_path, self.name + '_gt_roidb.pkl')
         if os.path.exists(cache_file):
             fid = gzip.open(cache_file,'rb')
             roidb = cPickle.load(fid)
             fid.close()
-            print '{} gt roidb loaded from {}'.format(self.name, cache_file)
+            print('{} gt roidb loaded from {}'.format(self.name, cache_file))
             return roidb
 
         gt_roidb = [self._load_vg_annotation(index)
@@ -186,7 +194,7 @@ class vg(imdb):
         fid = gzip.open(cache_file,'wb')
         cPickle.dump(gt_roidb, fid, cPickle.HIGHEST_PROTOCOL)
         fid.close()
-        print 'wrote gt roidb to {}'.format(cache_file)
+        print('wrote gt roidb to {}'.format(cache_file))
         return gt_roidb
 
     def _get_size(self, index):
@@ -227,7 +235,7 @@ class vg(imdb):
                 y2 = min(height-1,float(bbox.find('ymax').text))
                 # If bboxes are not positive, just give whole image coords (there are a few examples)
                 if x2 < x1 or y2 < y1:
-                    print 'Failed bbox in %s, object %s' % (filename, obj_name)
+                    print('Failed bbox in %s, object %s' % (filename, obj_name))
                     x1 = 0
                     y1 = 0
                     x2 = width-1
@@ -312,7 +320,7 @@ class vg(imdb):
         for cls_ind, cls in enumerate(classes):
             if cls == '__background__':
                 continue
-            print 'Writing "{}" vg results file'.format(cls)
+            print('Writing "{}" vg results file'.format(cls))
             filename = self._get_vg_results_file_template(output_dir).format(cls)
             with open(filename, 'wt') as f:
                 for im_ind, index in enumerate(self.image_index):
@@ -334,7 +342,7 @@ class vg(imdb):
         thresh = []
         # The PASCAL VOC metric changed in 2010
         use_07_metric = False
-        print 'VOC07 metric? ' + ('Yes' if use_07_metric else 'No')
+        print('VOC07 metric? ' + ('Yes' if use_07_metric else 'No'))
         if not os.path.isdir(output_dir):
             os.mkdir(output_dir)
         # Load ground truth

--- a/lib/datasets/vg_eval.py
+++ b/lib/datasets/vg_eval.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Fast/er R-CNN
 # Licensed under The MIT License [see LICENSE for details]
@@ -8,7 +9,7 @@ import xml.etree.ElementTree as ET
 import os
 import cPickle
 import numpy as np
-from voc_eval import voc_ap
+from .voc_eval import voc_ap
 
 
 

--- a/lib/model/nms/build.py
+++ b/lib/model/nms/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import torch
 from torch.utils.ffi import create_extension

--- a/lib/model/nms/nms_gpu.py
+++ b/lib/model/nms/nms_gpu.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import torch
 import numpy as np
-from _ext import nms
+from ._ext import nms
 import pdb
 
 def nms_gpu(dets, thresh):

--- a/lib/model/roi_align/build.py
+++ b/lib/model/roi_align/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import torch
 from torch.utils.ffi import create_extension

--- a/lib/model/roi_crop/build.py
+++ b/lib/model/roi_crop/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import torch
 from torch.utils.ffi import create_extension

--- a/lib/model/roi_pooling/build.py
+++ b/lib/model/roi_pooling/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import torch
 from torch.utils.ffi import create_extension

--- a/lib/model/rpn/anchor_target_layer.py
+++ b/lib/model/rpn/anchor_target_layer.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Faster R-CNN
 # Copyright (c) 2015 Microsoft
@@ -14,12 +15,18 @@ import numpy as np
 import numpy.random as npr
 
 from model.utils.config import cfg
-from generate_anchors import generate_anchors
-from bbox_transform import clip_boxes, bbox_overlaps_batch, bbox_transform_batch
+from .generate_anchors import generate_anchors
+from .bbox_transform import clip_boxes, bbox_overlaps_batch, bbox_transform_batch
 
 import pdb
 
 DEBUG = False
+
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 class _AnchorTargetLayer(nn.Module):
     """
@@ -117,9 +124,9 @@ class _AnchorTargetLayer(nn.Module):
             # subsample positive labels if we have too many
             if sum_fg[i] > num_fg:
                 fg_inds = torch.nonzero(labels[i] == 1).view(-1)
-                # torch.randperm seems has a bug on multi-gpu setting that cause the segfault. 
+                # torch.randperm seems has a bug on multi-gpu setting that cause the segfault.
                 # See https://github.com/pytorch/pytorch/issues/1868 for more details.
-                # use numpy instead.                
+                # use numpy instead.
                 #rand_num = torch.randperm(fg_inds.size(0)).type_as(gt_boxes).long()
                 rand_num = torch.from_numpy(np.random.permutation(fg_inds.size(0))).type_as(gt_boxes).long()
                 disable_inds = fg_inds[rand_num[:fg_inds.size(0)-num_fg]]

--- a/lib/model/rpn/generate_anchors.py
+++ b/lib/model/rpn/generate_anchors.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Faster R-CNN
 # Copyright (c) 2015 Microsoft
@@ -34,6 +35,12 @@ import pdb
 #       [ -35.,  -79.,   52.,   96.],
 #       [ -79., -167.,   96.,  184.],
 #       [-167., -343.,  184.,  360.]])
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def generate_anchors(base_size=16, ratios=[0.5, 1, 2],
                      scales=2**np.arange(3, 6)):
@@ -101,6 +108,6 @@ if __name__ == '__main__':
     import time
     t = time.time()
     a = generate_anchors()
-    print time.time() - t
-    print a
+    print(time.time() - t)
+    print(a)
     from IPython import embed; embed()

--- a/lib/model/rpn/proposal_layer.py
+++ b/lib/model/rpn/proposal_layer.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Faster R-CNN
 # Copyright (c) 2015 Microsoft
@@ -14,8 +15,8 @@ import numpy as np
 import math
 import yaml
 from model.utils.config import cfg
-from generate_anchors import generate_anchors
-from bbox_transform import bbox_transform_inv, clip_boxes, clip_boxes_batch
+from .generate_anchors import generate_anchors
+from .bbox_transform import bbox_transform_inv, clip_boxes, clip_boxes_batch
 from model.nms.nms_wrapper import nms
 
 import pdb

--- a/lib/model/rpn/proposal_target_layer_cascade.py
+++ b/lib/model/rpn/proposal_target_layer_cascade.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # --------------------------------------------------------
 # Faster R-CNN
 # Copyright (c) 2015 Microsoft
@@ -13,7 +14,7 @@ import torch.nn as nn
 import numpy as np
 import numpy.random as npr
 from ..utils.config import cfg
-from bbox_transform import bbox_overlaps_batch, bbox_transform_batch
+from .bbox_transform import bbox_overlaps_batch, bbox_transform_batch
 import pdb
 
 class _ProposalTargetLayer(nn.Module):

--- a/lib/model/rpn/rpn.py
+++ b/lib/model/rpn/rpn.py
@@ -1,11 +1,12 @@
+from __future__ import absolute_import
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 
 from model.utils.config import cfg
-from proposal_layer import _ProposalLayer
-from anchor_target_layer import _AnchorTargetLayer
+from .proposal_layer import _ProposalLayer
+from .anchor_target_layer import _AnchorTargetLayer
 from model.utils.net_utils import _smooth_l1_loss
 
 import numpy as np

--- a/lib/model/utils/blob.py
+++ b/lib/model/utils/blob.py
@@ -8,9 +8,13 @@
 """Blob helper functions."""
 
 import numpy as np
-#from scipy.misc import imread, imresize
+# from scipy.misc import imread, imresize
 import cv2
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 def im_list_to_blob(ims):
@@ -30,7 +34,7 @@ def im_list_to_blob(ims):
 
 def prep_im_for_blob(im, pixel_means, target_size, max_size):
     """Mean subtract and scale an image for use in a blob."""
-    
+
     im = im.astype(np.float32, copy=False)
     im -= pixel_means
     # im = im[:, :, ::-1]

--- a/lib/pycocotools/coco.py
+++ b/lib/pycocotools/coco.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 __author__ = 'tylin'
 __version__ = '1.0.1'
 # Interface for accessing the Microsoft COCO dataset.
@@ -55,7 +57,7 @@ import numpy as np
 import urllib
 import copy
 import itertools
-import mask
+from . import mask
 import os
 
 class COCO:
@@ -74,16 +76,16 @@ class COCO:
         self.imgs = {}
         self.cats = {}
         if not annotation_file == None:
-            print 'loading annotations into memory...'
+            print('loading annotations into memory...')
             tic = time.time()
             dataset = json.load(open(annotation_file, 'r'))
-            print 'Done (t=%0.2fs)'%(time.time()- tic)
+            print('Done (t=%0.2fs)'%(time.time()- tic))
             self.dataset = dataset
             self.createIndex()
 
     def createIndex(self):
         # create index
-        print 'creating index...'
+        print('creating index...')
         anns = {}
         imgToAnns = {}
         catToImgs = {}
@@ -110,7 +112,7 @@ class COCO:
                 for ann in self.dataset['annotations']:
                     catToImgs[ann['category_id']] += [ann['image_id']]
 
-        print 'index created!'
+        print('index created!')
 
         # create class members
         self.anns = anns
@@ -125,7 +127,7 @@ class COCO:
         :return:
         """
         for key, value in self.dataset['info'].items():
-            print '%s: %s'%(key, value)
+            print('%s: %s'%(key, value))
 
     def getAnnIds(self, imgIds=[], catIds=[], areaRng=[], iscrowd=None):
         """
@@ -276,7 +278,7 @@ class COCO:
             ax.add_collection(p)
         elif datasetType == 'captions':
             for ann in anns:
-                print ann['caption']
+                print(ann['caption'])
 
     def loadRes(self, resFile):
         """
@@ -289,7 +291,7 @@ class COCO:
         # res.dataset['info'] = copy.deepcopy(self.dataset['info'])
         # res.dataset['licenses'] = copy.deepcopy(self.dataset['licenses'])
 
-        print 'Loading and preparing results...     '
+        print('Loading and preparing results...     ')
         tic = time.time()
         anns    = json.load(open(resFile))
         assert type(anns) == list, 'results in not an array of objects'
@@ -320,7 +322,7 @@ class COCO:
                     ann['bbox'] = mask.toBbox([ann['segmentation']])[0]
                 ann['id'] = id+1
                 ann['iscrowd'] = 0
-        print 'DONE (t=%0.2fs)'%(time.time()- tic)
+        print('DONE (t=%0.2fs)'%(time.time()- tic))
 
         res.dataset['annotations'] = anns
         res.createIndex()
@@ -334,7 +336,7 @@ class COCO:
         :return:
         '''
         if tarDir is None:
-            print 'Please specify target directory'
+            print('Please specify target directory')
             return -1
         if len(imgIds) == 0:
             imgs = self.imgs.values()
@@ -348,4 +350,4 @@ class COCO:
             fname = os.path.join(tarDir, img['file_name'])
             if not os.path.exists(fname):
                 urllib.urlretrieve(img['coco_url'], fname)
-            print 'downloaded %d/%d images (t=%.1fs)'%(i, N, time.time()- tic)
+            print('downloaded %d/%d images (t=%.1fs)'%(i, N, time.time()- tic))

--- a/lib/pycocotools/cocoeval.py
+++ b/lib/pycocotools/cocoeval.py
@@ -1,11 +1,19 @@
+from __future__ import print_function
+from __future__ import absolute_import
 __author__ = 'tsungyi'
 
 import numpy as np
 import datetime
 import time
 from collections import defaultdict
-import mask
+from . import mask
 import copy
+
+try:
+    string_types = (str, unicode)  # Python 2
+except NameError:
+    string_types = (str, )         # Python 3
+
 
 class COCOeval:
     # Interface for evaluating detection on the Microsoft COCO dataset.
@@ -91,7 +99,7 @@ class COCOeval:
                 t = coco.imgs[obj['image_id']]
                 if type(obj['segmentation']) == list:
                     if type(obj['segmentation'][0]) == dict:
-                        print 'debug'
+                        print('debug')
                     obj['segmentation'] = mask.frPyObjects(obj['segmentation'],t['height'],t['width'])
                     if len(obj['segmentation']) == 1:
                         obj['segmentation'] = obj['segmentation'][0]
@@ -102,7 +110,7 @@ class COCOeval:
                 elif type(obj['segmentation']) == dict and type(obj['segmentation']['counts']) == list:
                     obj['segmentation'] = mask.frPyObjects([obj['segmentation']],t['height'],t['width'])[0]
                 elif type(obj['segmentation']) == dict and \
-                     type(obj['segmentation']['counts'] == unicode or type(obj['segmentation']['counts']) == str):
+                     type(obj['segmentation']['counts']) in string_types:
                     pass
                 else:
                     raise Exception('segmentation format not supported.')
@@ -132,7 +140,7 @@ class COCOeval:
         :return: None
         '''
         tic = time.time()
-        print 'Running per image evaluation...      '
+        print('Running per image evaluation...      ')
         p = self.params
         p.imgIds = list(np.unique(p.imgIds))
         if p.useCats:
@@ -158,7 +166,7 @@ class COCOeval:
              ]
         self._paramsEval = copy.deepcopy(self.params)
         toc = time.time()
-        print 'DONE (t=%0.2fs).'%(toc-tic)
+        print('DONE (t=%0.2fs).'%(toc-tic))
 
     def computeIoU(self, imgId, catId):
         p = self.params
@@ -212,7 +220,7 @@ class COCOeval:
 
         # sort dt highest score first, sort gt ignore last
         # gt = sorted(gt, key=lambda x: x['_ignore'])
-        gtind = [ind for (ind, g) in sorted(enumerate(gt), key=lambda (ind, g): g['_ignore']) ]
+        gtind = [ind for (ind, g) in sorted(enumerate(gt), key=lambda ind_g: ind_g[1]['_ignore']) ]
 
         gt = [gt[ind] for ind in gtind]
         dt = sorted(dt, key=lambda x: -x['score'])[0:maxDet]
@@ -277,10 +285,10 @@ class COCOeval:
         :param p: input params for evaluation
         :return: None
         '''
-        print 'Accumulating evaluation results...   '
+        print('Accumulating evaluation results...   ')
         tic = time.time()
         if not self.evalImgs:
-            print 'Please run evaluate() first'
+            print('Please run evaluate() first')
         # allows input customized parameters
         if p is None:
             p = self.params
@@ -371,7 +379,7 @@ class COCOeval:
             'recall':   recall,
         }
         toc = time.time()
-        print 'DONE (t=%0.2fs).'%( toc-tic )
+        print('DONE (t=%0.2fs).'%( toc-tic ))
 
     def summarize(self):
         '''
@@ -406,7 +414,7 @@ class COCOeval:
                 mean_s = -1
             else:
                 mean_s = np.mean(s[s>-1])
-            print iStr.format(titleStr, typeStr, iouStr, areaStr, maxDetsStr, '%.3f'%(float(mean_s)))
+            print(iStr.format(titleStr, typeStr, iouStr, areaStr, maxDetsStr, '%.3f'%(float(mean_s))))
             return mean_s
 
         if not self.eval:

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft
@@ -86,7 +87,7 @@ def customize_compiler_for_nvcc(self):
     # object but distutils doesn't have the ability to change compilers
     # based on source extension: we add it.
     def _compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
-        print extra_postargs
+        print(extra_postargs)
         if os.path.splitext(src)[1] == '.cu':
             # use the cuda for .cu files
             self.set_executable('compiler_so', CUDA['nvcc'])

--- a/test_net.py
+++ b/test_net.py
@@ -34,6 +34,12 @@ from model.faster_rcnn.resnet import resnet
 
 import pdb
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 def parse_args():
   """
   Parse input arguments
@@ -41,7 +47,7 @@ def parse_args():
   parser = argparse.ArgumentParser(description='Train a Fast R-CNN network')
   parser.add_argument('--dataset', dest='dataset',
                       help='training dataset',
-                      default='pascal_voc', type=str)  
+                      default='pascal_voc', type=str)
   parser.add_argument('--cfg', dest='cfg_file',
                       help='optional config file',
                       default='cfgs/vgg16.yml', type=str)
@@ -59,13 +65,13 @@ def parse_args():
                       action='store_true')
   parser.add_argument('--ls', dest='large_scale',
                       help='whether use large imag scale',
-                      action='store_true')                           
+                      action='store_true')
   parser.add_argument('--mGPUs', dest='mGPUs',
                       help='whether use multiple GPUs',
                       action='store_true')
   parser.add_argument('--cag', dest='class_agnostic',
                       help='whether perform class_agnostic bbox regression',
-                      action='store_true')                      
+                      action='store_true')
   parser.add_argument('--parallel_type', dest='parallel_type',
                       help='which part of model to parallel, 0: all, 1: model before roi pooling',
                       default=0, type=int)
@@ -83,7 +89,7 @@ def parse_args():
                       default=1, type=int)
   parser.add_argument('--vis', dest='vis',
                       help='visualization mode',
-                      action='store_true')  
+                      action='store_true')
   args = parser.parse_args()
   return args
 
@@ -159,7 +165,7 @@ if __name__ == '__main__':
     pdb.set_trace()
 
   fasterRCNN.create_architecture()
-  
+
   print("load checkpoint %s" % (load_name))
   checkpoint = torch.load(load_name)
   fasterRCNN.load_state_dict(checkpoint['model'])
@@ -197,7 +203,7 @@ if __name__ == '__main__':
   max_per_image = 100
 
   vis = args.vis
-  
+
   if vis:
     thresh = 0.05
   else:
@@ -220,11 +226,11 @@ if __name__ == '__main__':
   _t = {'im_detect': time.time(), 'misc': time.time()}
   det_file = os.path.join(output_dir, 'detections.pkl')
 
-  fasterRCNN.eval()  
+  fasterRCNN.eval()
   empty_array = np.transpose(np.array([[],[],[],[],[]]), (1,0))
   for i in range(num_images):
 
-      data = data_iter.next()
+      data = next(data_iter)
       im_data.data.resize_(data[0].size()).copy_(data[0])
       im_info.data.resize_(data[1].size()).copy_(data[1])
       gt_boxes.data.resize_(data[2].size()).copy_(data[2])
@@ -235,7 +241,7 @@ if __name__ == '__main__':
       rpn_loss_cls, rpn_loss_box, \
       RCNN_loss_cls, RCNN_loss_bbox, \
       rois_label = fasterRCNN(im_data, im_info, gt_boxes, num_boxes)
-      
+
       scores = cls_prob.data
       boxes = rois.data[:, :, 1:5]
 
@@ -260,8 +266,8 @@ if __name__ == '__main__':
           pred_boxes = np.tile(boxes, (1, scores.shape[1]))
 
       pred_boxes /= data[1][0][2]
-      
-      scores = scores.squeeze()    
+
+      scores = scores.squeeze()
       pred_boxes = pred_boxes.squeeze()
       det_toc = time.time()
       detect_time = det_toc - det_tic

--- a/trainval_net.py
+++ b/trainval_net.py
@@ -309,7 +309,7 @@ if __name__ == '__main__':
 
     data_iter = iter(dataloader)
     for step in range(iters_per_epoch):
-      data = data_iter.next()
+      data = next(data_iter)
       im_data.data.resize_(data[0].size()).copy_(data[0])
       im_info.data.resize_(data[1].size()).copy_(data[1])
       gt_boxes.data.resize_(data[2].size()).copy_(data[2])


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes