### PR TITLE
Allow DataLoader(num_workers=x>0)

### DIFF
--- a/lib/model/utils/blob.py
+++ b/lib/model/utils/blob.py
@@ -10,6 +10,7 @@
 import numpy as np
 # from scipy.misc import imread, imresize
 import cv2
+cv2.setNumThreads(0) # fix a multithreading problem to allow DataLoader(num_workers=x>0) 
 
 try:
     xrange          # Python 2

--- a/lib/model/utils/net_utils.py
+++ b/lib/model/utils/net_utils.py
@@ -7,6 +7,7 @@ import torchvision.models as models
 from model.utils.config import cfg
 from model.roi_crop.functions.roi_crop import RoICropFunction
 import cv2
+cv2.setNumThreads(0) # fix a multithreading problem to allow DataLoader(num_workers=x>0) 
 import pdb
 import random
 

--- a/test_net.py
+++ b/test_net.py
@@ -16,6 +16,7 @@ import pprint
 import pdb
 import time
 import cv2
+cv2.setNumThreads(0) # fix a multithreading problem to allow DataLoader(num_workers=x>0) 
 import torch
 from torch.autograd import Variable
 import torch.nn as nn


### PR DESCRIPTION
Fix multithreading conflict between cv2 and torch by disabling multithreading in cv2.

https://github.com/pytorch/pytorch/issues/1355

**Warning**: it works for me, but you should try this fix on your own computer before merging, thanks :)