### PR TITLE
fix: load_dir parameter is a string (a path)

### DIFF
--- a/test_net.py
+++ b/test_net.py
@@ -58,7 +58,7 @@ def parse_args():
                       nargs=argparse.REMAINDER)
   parser.add_argument('--load_dir', dest='load_dir',
                       help='directory to load models', default="/srv/share/jyang375/models",
-                      nargs=argparse.REMAINDER)
+                      type=str)
   parser.add_argument('--cuda', dest='cuda',
                       help='whether use CUDA',
                       action='store_true')


### PR DESCRIPTION
otherwise I get
  File "test_net.py", line 147, in <module>
    input_dir = args.load_dir + "/" + args.net + "/" + args.dataset
TypeError: can only concatenate list (not "str") to list