### PR TITLE
Update anchor_target_layer.py

### DIFF
--- a/lib/model/rpn/anchor_target_layer.py
+++ b/lib/model/rpn/anchor_target_layer.py
@@ -132,8 +132,8 @@ class _AnchorTargetLayer(nn.Module):
                 disable_inds = fg_inds[rand_num[:fg_inds.size(0)-num_fg]]
                 labels[i][disable_inds] = -1
 
-#             num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
-            num_bg = cfg.TRAIN.RPN_BATCHSIZE - np.sum(labels == 1)[i]
+#           num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
+            num_bg = cfg.TRAIN.RPN_BATCHSIZE - torch.sum((labels == 1).int(), 1)[i]
 
             # subsample negative labels if we have too many
             if sum_bg[i] > num_bg:

--- a/lib/model/rpn/anchor_target_layer.py
+++ b/lib/model/rpn/anchor_target_layer.py
@@ -132,6 +132,7 @@ class _AnchorTargetLayer(nn.Module):
                 disable_inds = fg_inds[rand_num[:fg_inds.size(0)-num_fg]]
                 labels[i][disable_inds] = -1
 
+#             num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
             num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
 
             # subsample negative labels if we have too many

--- a/lib/model/rpn/anchor_target_layer.py
+++ b/lib/model/rpn/anchor_target_layer.py
@@ -133,7 +133,7 @@ class _AnchorTargetLayer(nn.Module):
                 labels[i][disable_inds] = -1
 
 #             num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
-            num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]
+            num_bg = cfg.TRAIN.RPN_BATCHSIZE - np.sum(labels == 1)[i]
 
             # subsample negative labels if we have too many
             if sum_bg[i] > num_bg:


### PR DESCRIPTION
When sum_fg[i] > num_fg, the positive labels will be subsampled according to your code. And I think the num_bg should be calculated by the updated number of positive labels.  If not, the number of the RPN training samples will be less than RPN_BATCH_SIZE in this case. 
`num_bg = cfg.TRAIN.RPN_BATCHSIZE - sum_fg[i]` can be changed to `num_bg = cfg.TRAIN.RPN_BATCHSIZE - torch.sum((labels == 1).int(), 1)[i]`

I reviewed the original faster_rcnn's anthor_target_layer.py  in [https://github.com/rbgirshick/py-faster-rcnn/blob/master/lib/rpn/anchor_target_layer.py](url), which also use `num_bg = cfg.TRAIN.RPN_BATCHSIZE - np.sum(labels == 1)`  to re-calculate num_bg.