### PR TITLE
Add cpu version of roi_align and nms layer, modify demo.py 

### DIFF
--- a/lib/model/nms/nms_cpu.py
+++ b/lib/model/nms/nms_cpu.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import numpy as np
+import torch
+
+def nms_cpu(dets, thresh):
+    dets = dets.numpy()
+    x1 = dets[:, 0]
+    y1 = dets[:, 1]
+    x2 = dets[:, 2]
+    y2 = dets[:, 3]
+    scores = dets[:, 4]
+
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
+    order = scores.argsort()[::-1]
+
+    keep = []
+    while order.size > 0:
+        i = order.item(0)
+        keep.append(i)
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.maximum(x2[i], x2[order[1:]])
+        yy2 = np.maximum(y2[i], y2[order[1:]])
+
+        w = np.maximum(0.0, xx2 - xx1 + 1)
+        h = np.maximum(0.0, yy2 - yy1 + 1)
+        inter = w * h
+        ovr = inter / (areas[i] + areas[order[1:]] - inter)
+
+        inds = np.where(ovr <= thresh)[0]
+        order = order[inds + 1]
+
+    return torch.IntTensor(keep)
+
+

--- a/lib/model/nms/nms_wrapper.py
+++ b/lib/model/nms/nms_wrapper.py
@@ -6,7 +6,9 @@
 # --------------------------------------------------------
 import torch
 from model.utils.config import cfg
-from model.nms.nms_gpu import nms_gpu
+if torch.cuda.is_available():
+    from model.nms.nms_gpu import nms_gpu
+from model.nms.nms_cpu import nms_cpu
 
 def nms(dets, thresh, force_cpu=False):
     """Dispatch to either CPU or GPU NMS implementations."""
@@ -15,4 +17,5 @@ def nms(dets, thresh, force_cpu=False):
     # ---numpy version---
     # original: return gpu_nms(dets, thresh, device_id=cfg.GPU_ID)
     # ---pytorch version---
-    return nms_gpu(dets, thresh)
+
+    return nms_gpu(dets, thresh) if force_cpu == False else nms_cpu(dets, thresh)

--- a/lib/model/roi_align/build.py
+++ b/lib/model/roi_align/build.py
@@ -3,12 +3,16 @@ import os
 import torch
 from torch.utils.ffi import create_extension
 
-# sources = ['src/roi_align.c']
-# headers = ['src/roi_align.h']
-sources = []
-headers = []
+sources = ['src/roi_align.c']
+headers = ['src/roi_align.h']
+extra_objects = []
+#sources = []
+#headers = []
 defines = []
 with_cuda = False
+
+this_file = os.path.dirname(os.path.realpath(__file__))
+print(this_file)
 
 if torch.cuda.is_available():
     print('Including CUDA code.')
@@ -16,11 +20,9 @@ if torch.cuda.is_available():
     headers += ['src/roi_align_cuda.h']
     defines += [('WITH_CUDA', None)]
     with_cuda = True
-
-this_file = os.path.dirname(os.path.realpath(__file__))
-print(this_file)
-extra_objects = ['src/roi_align_kernel.cu.o']
-extra_objects = [os.path.join(this_file, fname) for fname in extra_objects]
+    
+    extra_objects = ['src/roi_align_kernel.cu.o']
+    extra_objects = [os.path.join(this_file, fname) for fname in extra_objects]
 
 ffi = create_extension(
     '_ext.roi_align',

--- a/lib/model/roi_align/functions/roi_align.py
+++ b/lib/model/roi_align/functions/roi_align.py
@@ -26,7 +26,11 @@ class RoIAlignFunction(Function):
                                              self.spatial_scale, features,
                                              rois, output)
         else:
-            raise NotImplementedError
+            roi_align.roi_align_forward(self.aligned_height,
+                                        self.aligned_width,
+                                        self.spatial_scale, features,
+                                        rois, output)
+#            raise NotImplementedError
 
         return output
 

--- a/lib/model/roi_align/src/roi_align.c
+++ b/lib/model/roi_align/src/roi_align.c
@@ -1,0 +1,190 @@
+#include <TH/TH.h>
+#include <math.h>
+#include <omp.h>
+
+
+void ROIAlignForwardCpu(const float* bottom_data, const float spatial_scale, const int num_rois,
+                     const int height, const int width, const int channels,
+                     const int aligned_height, const int aligned_width, const float * bottom_rois,
+                     float* top_data);
+
+void ROIAlignBackwardCpu(const float* top_diff, const float spatial_scale, const int num_rois,
+                     const int height, const int width, const int channels,
+                     const int aligned_height, const int aligned_width, const float * bottom_rois,
+                     float* top_data);
+
+int roi_align_forward(int aligned_height, int aligned_width, float spatial_scale,
+                     THFloatTensor * features, THFloatTensor * rois, THFloatTensor * output)
+{
+    //Grab the input tensor
+    float * data_flat = THFloatTensor_data(features);
+    float * rois_flat = THFloatTensor_data(rois);
+
+    float * output_flat = THFloatTensor_data(output);
+
+    // Number of ROIs
+    int num_rois = THFloatTensor_size(rois, 0);
+    int size_rois = THFloatTensor_size(rois, 1);
+    if (size_rois != 5)
+    {
+        return 0;
+    }
+
+    // data height
+    int data_height = THFloatTensor_size(features, 2);
+    // data width
+    int data_width = THFloatTensor_size(features, 3);
+    // Number of channels
+    int num_channels = THFloatTensor_size(features, 1);
+
+    // do ROIAlignForward
+    ROIAlignForwardCpu(data_flat, spatial_scale, num_rois, data_height, data_width, num_channels,
+            aligned_height, aligned_width, rois_flat, output_flat);
+
+    return 1;
+}
+
+int roi_align_backward(int aligned_height, int aligned_width, float spatial_scale,
+                       THFloatTensor * top_grad, THFloatTensor * rois, THFloatTensor * bottom_grad)
+{
+    //Grab the input tensor
+    float * top_grad_flat = THFloatTensor_data(top_grad);
+    float * rois_flat = THFloatTensor_data(rois);
+
+    float * bottom_grad_flat = THFloatTensor_data(bottom_grad);
+
+    // Number of ROIs
+    int num_rois = THFloatTensor_size(rois, 0);
+    int size_rois = THFloatTensor_size(rois, 1);
+    if (size_rois != 5)
+    {
+        return 0;
+    }
+
+    // batch size
+    int batch_size = THFloatTensor_size(bottom_grad, 0);
+    // data height
+    int data_height = THFloatTensor_size(bottom_grad, 2);
+    // data width
+    int data_width = THFloatTensor_size(bottom_grad, 3);
+    // Number of channels
+    int num_channels = THFloatTensor_size(bottom_grad, 1);
+
+    // do ROIAlignBackward
+    ROIAlignBackwardCpu(top_grad_flat, spatial_scale, num_rois, data_height,
+            data_width, num_channels, aligned_height, aligned_width, rois_flat, bottom_grad_flat);
+
+    return 1;
+}
+
+void ROIAlignForwardCpu(const float* bottom_data, const float spatial_scale, const int num_rois,
+                     const int height, const int width, const int channels,
+                     const int aligned_height, const int aligned_width, const float * bottom_rois,
+                     float* top_data)
+{
+    const int output_size = num_rois * aligned_height * aligned_width * channels;
+
+    #pragma omp parallel for 
+    for (int idx = 0; idx < output_size; ++idx)
+    {
+        // (n, c, ph, pw) is an element in the aligned output
+        int pw = idx % aligned_width;
+        int ph = (idx / aligned_width) % aligned_height;
+        int c = (idx / aligned_width / aligned_height) % channels;
+        int n = idx / aligned_width / aligned_height / channels;
+
+        float roi_batch_ind = bottom_rois[n * 5 + 0];
+        float roi_start_w = bottom_rois[n * 5 + 1] * spatial_scale;
+        float roi_start_h = bottom_rois[n * 5 + 2] * spatial_scale;
+        float roi_end_w = bottom_rois[n * 5 + 3] * spatial_scale;
+        float roi_end_h = bottom_rois[n * 5 + 4] * spatial_scale;
+
+        // Force malformed ROI to be 1x1
+        float roi_width = fmaxf(roi_end_w - roi_start_w + 1., 0.);
+        float roi_height = fmaxf(roi_end_h - roi_start_h + 1., 0.);
+        float bin_size_h = roi_height / (aligned_height - 1.);
+        float bin_size_w = roi_width / (aligned_width - 1.);
+
+        float h = (float)(ph) * bin_size_h + roi_start_h;
+        float w = (float)(pw) * bin_size_w + roi_start_w;
+
+        int hstart = fminf(floor(h), height - 2);
+        int wstart = fminf(floor(w), width - 2);
+
+        int img_start = roi_batch_ind * channels * height * width;
+
+        // bilinear interpolation
+        if (h < 0 || h >= height || w < 0 || w >= width)
+        {
+            top_data[idx] = 0.;
+        }
+        else
+        {
+            float h_ratio = h - (float)(hstart);
+            float w_ratio = w - (float)(wstart);
+            int upleft = img_start + (c * height + hstart) * width + wstart;
+            int upright = upleft + 1;
+            int downleft = upleft + width;
+            int downright = downleft + 1;
+
+            top_data[idx] = bottom_data[upleft] * (1. - h_ratio) * (1. - w_ratio)
+                + bottom_data[upright] * (1. - h_ratio) * w_ratio
+                + bottom_data[downleft] * h_ratio * (1. - w_ratio)
+                + bottom_data[downright] * h_ratio * w_ratio;
+        }
+    }
+}
+
+void ROIAlignBackwardCpu(const float* top_diff, const float spatial_scale, const int num_rois,
+                     const int height, const int width, const int channels,
+                     const int aligned_height, const int aligned_width, const float * bottom_rois,
+                     float* bottom_diff)
+{
+    const int output_size = num_rois * aligned_height * aligned_width * channels;
+
+    #pragma omp parallel for 
+    for (int idx = 0; idx < output_size; ++idx)
+    {
+        // (n, c, ph, pw) is an element in the aligned output
+        int pw = idx % aligned_width;
+        int ph = (idx / aligned_width) % aligned_height;
+        int c = (idx / aligned_width / aligned_height) % channels;
+        int n = idx / aligned_width / aligned_height / channels;
+
+        float roi_batch_ind = bottom_rois[n * 5 + 0];
+        float roi_start_w = bottom_rois[n * 5 + 1] * spatial_scale;
+        float roi_start_h = bottom_rois[n * 5 + 2] * spatial_scale;
+        float roi_end_w = bottom_rois[n * 5 + 3] * spatial_scale;
+        float roi_end_h = bottom_rois[n * 5 + 4] * spatial_scale;
+
+        // Force malformed ROI to be 1x1
+        float roi_width = fmaxf(roi_end_w - roi_start_w + 1., 0.);
+        float roi_height = fmaxf(roi_end_h - roi_start_h + 1., 0.);
+        float bin_size_h = roi_height / (aligned_height - 1.);
+        float bin_size_w = roi_width / (aligned_width - 1.);
+
+        float h = (float)(ph) * bin_size_h + roi_start_h;
+        float w = (float)(pw) * bin_size_w + roi_start_w;
+
+        int hstart = fminf(floor(h), height - 2);
+        int wstart = fminf(floor(w), width - 2);
+
+        int img_start = roi_batch_ind * channels * height * width;
+
+        // bilinear interpolation
+        if (h < 0 || h >= height || w < 0 || w >= width)
+        {
+            float h_ratio = h - (float)(hstart);
+            float w_ratio = w - (float)(wstart);
+            int upleft = img_start + (c * height + hstart) * width + wstart;
+            int upright = upleft + 1;
+            int downleft = upleft + width;
+            int downright = downleft + 1;
+
+            bottom_diff[upleft] += top_diff[idx] * (1. - h_ratio) * (1. - w_ratio);
+            bottom_diff[upright] += top_diff[idx] * (1. - h_ratio) *  w_ratio;
+            bottom_diff[downleft] += top_diff[idx] * h_ratio * (1. - w_ratio);
+            bottom_diff[downright] += top_diff[idx] * h_ratio * w_ratio;
+        }
+    }
+}

--- a/lib/model/roi_align/src/roi_align.h
+++ b/lib/model/roi_align/src/roi_align.h
@@ -1,0 +1,5 @@
+int roi_align_forward(int aligned_height, int aligned_width, float spatial_scale,
+                      THFloatTensor * features, THFloatTensor * rois, THFloatTensor * output);
+
+int roi_align_backward(int aligned_height, int aligned_width, float spatial_scale,
+                      THFloatTensor * top_grad, THFloatTensor * rois, THFloatTensor * bottom_grad);

--- a/lib/model/roi_pooling/build.py
+++ b/lib/model/roi_pooling/build.py
@@ -6,8 +6,12 @@ from torch.utils.ffi import create_extension
 
 sources = ['src/roi_pooling.c']
 headers = ['src/roi_pooling.h']
+extra_objects = []
 defines = []
 with_cuda = False
+
+this_file = os.path.dirname(os.path.realpath(__file__))
+print(this_file)
 
 if torch.cuda.is_available():
     print('Including CUDA code.')
@@ -15,11 +19,8 @@ if torch.cuda.is_available():
     headers += ['src/roi_pooling_cuda.h']
     defines += [('WITH_CUDA', None)]
     with_cuda = True
-
-this_file = os.path.dirname(os.path.realpath(__file__))
-print(this_file)
-extra_objects = ['src/roi_pooling.cu.o']
-extra_objects = [os.path.join(this_file, fname) for fname in extra_objects]
+    extra_objects = ['src/roi_pooling.cu.o']
+    extra_objects = [os.path.join(this_file, fname) for fname in extra_objects]
 
 ffi = create_extension(
     '_ext.roi_pooling',

--- a/lib/model/rpn/proposal_layer.py
+++ b/lib/model/rpn/proposal_layer.py
@@ -145,7 +145,7 @@ class _ProposalLayer(nn.Module):
             # 7. take after_nms_topN (e.g. 300)
             # 8. return the top proposals (-> RoIs top)
 
-            keep_idx_i = nms(torch.cat((proposals_single, scores_single), 1), nms_thresh)
+            keep_idx_i = nms(torch.cat((proposals_single, scores_single), 1), nms_thresh, force_cpu=not cfg.USE_GPU_NMS)
             keep_idx_i = keep_idx_i.long().view(-1)
 
             if post_nms_topN > 0:


### PR DESCRIPTION
I added cpu version of roi_align and nms layers.
The nms layer was made with reference to longcw's codes (https://github.com/longcw/yolo2-pytorch/blob/master/utils/nms/py_cpu_nms.py)
The roi_align layer needs gcc compilation (roi_align.c) and c code was made with reference to gpu code.
Cpu version is only worked on 'forward' with assumption that is used only at test time.
'demo.py' was modified for both gpu and cpu mode.
