### PR TITLE
Fix save_dir command line option

### DIFF
--- a/trainval_net.py
+++ b/trainval_net.py
@@ -59,7 +59,7 @@ def parse_args():
 
   parser.add_argument('--save_dir', dest='save_dir',
                       help='directory to save models', default="/srv/share/jyang375/models",
-                      nargs=argparse.REMAINDER)
+                      type=str)
   parser.add_argument('--nw', dest='num_workers',
                       help='number of worker to load data',
                       default=0, type=int)


### PR DESCRIPTION
I got an error about appending strings to a list before this fix.