### PR TITLE
Replaced the use of Tensor.index(m) with Tensor[m]

### DIFF
--- a/lib/model/rpn/proposal_target_layer_cascade.py
+++ b/lib/model/rpn/proposal_target_layer_cascade.py
@@ -130,7 +130,7 @@ class _ProposalTargetLayer(nn.Module):
         offset = torch.arange(0, batch_size)*gt_boxes.size(1)
         offset = offset.view(-1, 1).type_as(gt_assignment) + gt_assignment
 
-        labels = gt_boxes[:,:,4].contiguous().view(-1).index((offset.view(-1),)).view(batch_size, -1)
+        labels = gt_boxes[:,:,4].contiguous().view(-1)[(offset.view(-1),)].view(batch_size, -1)
 
         labels_batch = labels.new(batch_size, rois_per_image).zero_()
         rois_batch  = all_rois.new(batch_size, rois_per_image, 5).zero_()


### PR DESCRIPTION
The later versions of pytorch don't seem to support the tensor.index function. Hence, I have replaced the `index` function with the `[]` indexing.