### PR TITLE
Move model to GPU before loading checkpoint data

### DIFF
--- a/trainval_net.py
+++ b/trainval_net.py
@@ -269,6 +269,9 @@ if __name__ == '__main__':
   elif args.optimizer == "sgd":
     optimizer = torch.optim.SGD(params, momentum=cfg.TRAIN.MOMENTUM)
 
+  if args.cuda:
+    fasterRCNN.cuda()
+
   if args.resume:
     load_name = os.path.join(output_dir,
       'faster_rcnn_{}_{}_{}.pth'.format(args.checksession, args.checkepoch, args.checkpoint))
@@ -285,9 +288,6 @@ if __name__ == '__main__':
 
   if args.mGPUs:
     fasterRCNN = nn.DataParallel(fasterRCNN)
-
-  if args.cuda:
-    fasterRCNN.cuda()
 
   iters_per_epoch = int(train_size / args.batch_size)
 


### PR DESCRIPTION
Addresses a number of reported issues (e.g #325 #222 ) relating to resuming a CUDA-trained model.