### PR TITLE
fixes user warning in demo.py

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -216,10 +216,11 @@ if __name__ == '__main__':
     gt_boxes = gt_boxes.cuda()
 
   # make variable
-  im_data = Variable(im_data, volatile=True)
-  im_info = Variable(im_info, volatile=True)
-  num_boxes = Variable(num_boxes, volatile=True)
-  gt_boxes = Variable(gt_boxes, volatile=True)
+  with torch.no_grad():
+    im_data = Variable(im_data)
+    im_info = Variable(im_info)
+    num_boxes = Variable(num_boxes)
+    gt_boxes = Variable(gt_boxes)
 
   if args.cuda > 0:
     cfg.CUDA = True


### PR DESCRIPTION
When I run demo.py, I found an user warning that asked me to replace "volatile=True" with "with torch.no_grad():", so I changed the code and the warning disappeared.

Here is the User Warning:
"UserWarning: volatile was removed and now has no effect. Use `with torch.no_grad():` instead."