### PR TITLE
Remove "for training" in get_roidb

### DIFF
--- a/lib/roi_data_layer/roidb.py
+++ b/lib/roi_data_layer/roidb.py
@@ -120,7 +120,7 @@ def combined_roidb(imdb_names, training=True):
   
   def get_roidb(imdb_name):
     imdb = get_imdb(imdb_name)
-    print('Loaded dataset `{:s}` for training'.format(imdb.name))
+    print('Loaded dataset `{:s}`'.format(imdb.name))
     imdb.set_proposal_method(cfg.TRAIN.PROPOSAL_METHOD)
     print('Set proposal method: {:s}'.format(cfg.TRAIN.PROPOSAL_METHOD))
     roidb = get_training_roidb(imdb)


### PR DESCRIPTION
`get_roidb` will be indirectly called by test_net.py.
This PR removes "for training" because it's misleading.