### PR TITLE
noticed hardcoded inplanes under ResNet implementation

### DIFF
--- a/lib/model/faster_rcnn/resnet.py
+++ b/lib/model/faster_rcnn/resnet.py
@@ -106,7 +106,7 @@ class ResNet(nn.Module):
   def __init__(self, block, layers, num_classes=1000):
     self.inplanes = 64
     super(ResNet, self).__init__()
-    self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3,
+    self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,
                  bias=False)
     self.bn1 = nn.BatchNorm2d(64)
     self.relu = nn.ReLU(inplace=True)


### PR DESCRIPTION
If you compare this with the PyTorch implementation of ResNet, you notice the hardcoding